### PR TITLE
RESJOSIE-301 Created a chrono-date component for date inputs

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -222,8 +222,7 @@ export class AppComponent {
     condition: 'and',
     rules: [
       {field: 'age', operator: '<=', entity: 'physical'},
-      // {field: 'birthday', operator: '=', value: new Date(), entity: 'nonphysical'},
-      {field: 'birthday', operator: '=', entity:'nonphysical'},
+      {field: 'birthday', operator: '=', value: new Date(), entity: 'nonphysical'},
       {
         condition: 'or',
         rules: [

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -222,7 +222,8 @@ export class AppComponent {
     condition: 'and',
     rules: [
       {field: 'age', operator: '<=', entity: 'physical'},
-      {field: 'birthday', operator: '=', value: new Date(), entity: 'nonphysical'},
+      // {field: 'birthday', operator: '=', value: new Date(), entity: 'nonphysical'},
+      {field: 'birthday', operator: '=', entity:'nonphysical'},
       {
         condition: 'or',
         rules: [

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "zone.js": "~0.10.2"
   },
   "dependencies": {
+    "chrono-node": "^2.1.9",
     "tslib": "^1.10.0"
   }
 }

--- a/projects/angular2-query-builder/src/lib/angular2-query-builder.module.ts
+++ b/projects/angular2-query-builder/src/lib/angular2-query-builder.module.ts
@@ -13,6 +13,7 @@ import { QueryButtonGroupDirective } from './query-builder/query-button-group.di
 import { QuerySwitchGroupDirective } from './query-builder/query-switch-group.directive';
 import { QueryRemoveButtonDirective } from './query-builder/query-remove-button.directive';
 import { QueryEmptyWarningDirective } from './query-builder/query-empty-warning.directive';
+import { ChronoDateComponent } from './query-builder/chrono/chrono-date/chrono-date.component';
 
 @NgModule({
   imports: [
@@ -29,7 +30,8 @@ import { QueryEmptyWarningDirective } from './query-builder/query-empty-warning.
     QuerySwitchGroupDirective,
     QueryRemoveButtonDirective,
     QueryEmptyWarningDirective,
-    QueryArrowIconDirective
+    QueryArrowIconDirective,
+    ChronoDateComponent
   ],
   exports: [
     QueryBuilderComponent,
@@ -41,7 +43,8 @@ import { QueryEmptyWarningDirective } from './query-builder/query-empty-warning.
     QuerySwitchGroupDirective,
     QueryRemoveButtonDirective,
     QueryEmptyWarningDirective,
-    QueryArrowIconDirective
+    QueryArrowIconDirective,
+    ChronoDateComponent
   ]
 })
 export class QueryBuilderModule { }

--- a/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.spec.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChronoDateComponent } from './chrono-date.component';
+
+describe('ChronoDateComponent', () => {
+  let component: ChronoDateComponent;
+  let fixture: ComponentFixture<ChronoDateComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ChronoDateComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChronoDateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
@@ -5,8 +5,8 @@ import * as chrono from 'chrono-node';
 @Component({
   selector: 'chrono-date',
   template: `
-  <input id="txt" name="txt" #txt="ngModel" type="text" [(ngModel)]="text" (change)="textUpdate($event)" >
-  <input id="cal" name="cal" #cal="ngModel" type="date" [(ngModel)]="date" (change)="calendarUpdate($event)">
+  <input #txt="ngModel" type="text" [(ngModel)]="text" (change)="textUpdate($event)" >
+  <input #cal="ngModel" type="date" [(ngModel)]="date" (change)="calendarUpdate($event)">
   <span class="chrono-alert" *ngIf="!textValid && txt.touched">Unable to parse text</span>
   `,
   styles: [`

--- a/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
@@ -5,9 +5,9 @@ import * as chrono from 'chrono-node';
 @Component({
   selector: 'chrono-date',
   template: `
-  <input #txt="ngModel" type="text" [(ngModel)]="text" (change)="textUpdate($event)" >
+  <input #txt="ngModel" type="text" [(ngModel)]="text" (change)="textUpdate($event)">
   <input #cal="ngModel" type="date" [(ngModel)]="date" (change)="calendarUpdate($event)">
-  <span class="chrono-alert" *ngIf="!textValid && txt.touched">Unable to parse text</span>
+  <span class="chrono-alert" *ngIf="!textValid && txt.touched">Unable to parse date</span>
   `,
   styles: [`
   .chrono-alert {

--- a/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
@@ -1,0 +1,74 @@
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Component, OnInit, Output, EventEmitter, Input, forwardRef } from '@angular/core';
+import * as chrono from 'chrono-node';
+
+@Component({
+  selector: 'chrono-date',
+  template: `
+  <input id="txt" name="txt" #txt="ngModel" type="text" [(ngModel)]="text" (change)="textUpdate($event)" >
+  <input id="cal" name="cal" #cal="ngModel" type="date" [(ngModel)]="date" (change)="calendarUpdate($event)">
+  <span class="chrono-alert" *ngIf="!textValid && txt.touched">Unable to parse text</span>
+  `,
+  styles: [`
+  .chrono-alert {
+    color: red;
+    padding: 0 10px;
+  }
+
+  :host.q-input-control {
+    padding: 2px 2px !important;
+  }
+  `],
+  providers: [{
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => ChronoDateComponent),
+    multi: true
+  }]
+})
+export class ChronoDateComponent implements OnInit, ControlValueAccessor {
+
+  @Input() date: string;
+  public text;
+  public textValid;
+
+  onChange = (_ => {});
+  onBlur = (_ => {});
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  textUpdate($event) {
+    let parsed = chrono.parse(this.text);
+    if (parsed.length > 0) {
+      this.textValid = true;
+      let date = parsed[0].date().toISOString().slice(0,10);
+      this.date = date;
+      this.onChange(this.date);
+    } else {
+      this.textValid = false;
+      this.date = '';
+      this.onChange(this.date);
+    }
+  };
+
+  calendarUpdate($event) {
+    this.textValid = true;
+    this.text = '';
+    this.onChange(this.date);
+  }
+
+  writeValue(obj: string): void {
+    this.date = obj;
+  }
+
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onBlur = fn;
+  }
+
+}

--- a/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
@@ -11,7 +11,10 @@ import * as chrono from 'chrono-node';
       <span class="icon-wrapper">
         <span class="calendar">
           <input #cal="ngModel" type="date" [(ngModel)]="date" (change)="calendarUpdate($event)">
-          <i class="material-icons">calendar_today</i>
+          <svg class="icon" viewBox="0 0 24 24" fill="black">
+            <path d="M0 0h24v24H0z" fill="none"/>
+            <path d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"/>
+          </svg>
         </span>
       </span>
     </div>
@@ -22,19 +25,17 @@ import * as chrono from 'chrono-node';
   .calendar {
     display: inline-block;
     position: relative;
-    line-height: 0;
   }
 
   .calendar input[type="date"] {
     position: absolute;
     opacity: 0;
-    width: 100%;
-    height: 100%;
+    height: 24px;
     border: 0;
     overflow: hidden;
     cursor: pointer;
-    clip-path: inset(0 17px 0 0);
-    width: 40px;
+    clip-path: inset(0 17px 0 0); /* for firefox fix */
+    width: 41px; /* for firefox fix */
   }
 
   .calendar input[type="date"]::-webkit-calendar-picker-indicator {
@@ -50,14 +51,16 @@ import * as chrono from 'chrono-node';
     background-color: silver;
   }
 
-  .calendar .material-icons {
-    line-height: 21px;
+  .calendar .icon {
+    width: 24px;
+    height: 24px;
   }
   
   .icon-wrapper {
-    display:inline-flex;
+    display: inline-flex;
     position: absolute;
     right: 5px;
+    top: 4px;
   }
 
   .textbox {
@@ -65,6 +68,7 @@ import * as chrono from 'chrono-node';
     border: 1px solid #ccc;
     border-radius: 4px;
     box-sizing: border-box;
+    min-height: 32px;
   }
 
   .input-wrapper {
@@ -78,7 +82,6 @@ import * as chrono from 'chrono-node';
     display: inline-flex;
     vertical-align: middle;
     align-items: center;
-    position: relative;
   }
   
   .chrono-alert {

--- a/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
@@ -81,7 +81,6 @@ import * as chrono from 'chrono-node';
     position: relative;
   }
   
-  
   .chrono-alert {
     color: red;
     margin: 0 10px;
@@ -114,17 +113,6 @@ export class ChronoDateComponent implements OnInit, ControlValueAccessor {
   }
 
   textUpdate($event) {
-    // let parsed = chrono.parse(this.text);
-    // if (parsed.length > 0) {
-    //   this.textValid = true;
-    //   let date = parsed[0].date().toISOString().slice(0,10);
-    //   this.date = date;
-    //   this.onChange(this.date);
-    // } else {
-    //   this.textValid = false;
-    //   this.date = '';
-    //   this.onChange(this.date);
-    // }
     let parsed = chrono.parse(this.text);
     if (parsed.length > 0) {
       this.textValid = true;
@@ -142,7 +130,6 @@ export class ChronoDateComponent implements OnInit, ControlValueAccessor {
   calendarUpdate($event) {
     console.log("hello");
     this.textValid = true;
-    // this.text = '';
     this.text = this.date;
     this.onChange(this.date);
   }

--- a/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
+++ b/projects/angular2-query-builder/src/lib/query-builder/chrono/chrono-date/chrono-date.component.ts
@@ -4,20 +4,94 @@ import * as chrono from 'chrono-node';
 
 @Component({
   selector: 'chrono-date',
-  template: `
-  <input #txt="ngModel" type="text" [(ngModel)]="text" (change)="textUpdate($event)">
-  <input #cal="ngModel" type="date" [(ngModel)]="date" (change)="calendarUpdate($event)">
-  <span class="chrono-alert" *ngIf="!textValid && txt.touched">Unable to parse date</span>
+  template: ` 
+  <div class="outer-wrapper">
+    <div class="input-wrapper">
+      <input class="textbox" #txt="ngModel" type="text" [(ngModel)]="text" (change)="textUpdate($event)" placeholder="yyyy-mm-dd">
+      <span class="icon-wrapper">
+        <span class="calendar">
+          <input #cal="ngModel" type="date" [(ngModel)]="date" (change)="calendarUpdate($event)">
+          <i class="material-icons">calendar_today</i>
+        </span>
+      </span>
+    </div>
+    <span class="chrono-alert" *ngIf="!textValid && txt.touched">Unable to parse date</span>
+  </div>
   `,
   styles: [`
+  .calendar {
+    display: inline-block;
+    position: relative;
+    line-height: 0;
+  }
+
+  .calendar input[type="date"] {
+    position: absolute;
+    opacity: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    overflow: hidden;
+    cursor: pointer;
+    clip-path: inset(0 17px 0 0);
+    width: 40px;
+  }
+
+  .calendar input[type="date"]::-webkit-calendar-picker-indicator {
+    position: absolute;
+    top: -150%;
+    left: -150%;
+    width: 300%;
+    height: 300%;
+    cursor: pointer;
+  }
+  
+  .calendar input[type="date"]:hover + button {
+    background-color: silver;
+  }
+
+  .calendar .material-icons {
+    line-height: 21px;
+  }
+  
+  .icon-wrapper {
+    display:inline-flex;
+    position: absolute;
+    right: 5px;
+  }
+
+  .textbox {
+    padding: 5px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
+
+  .input-wrapper {
+    display: inline-flex;
+    vertical-align: middle;
+    align-items: center;
+    position: relative;
+  }
+
+  .outer-wrapper {
+    display: inline-flex;
+    vertical-align: middle;
+    align-items: center;
+    position: relative;
+  }
+  
+  
   .chrono-alert {
     color: red;
-    padding: 0 10px;
+    margin: 0 10px;
   }
 
   :host.q-input-control {
-    padding: 2px 2px !important;
+    border: none !important;
+    padding: 0 !important;
   }
+  
   `],
   providers: [{
     provide: NG_VALUE_ACCESSOR,
@@ -40,11 +114,23 @@ export class ChronoDateComponent implements OnInit, ControlValueAccessor {
   }
 
   textUpdate($event) {
+    // let parsed = chrono.parse(this.text);
+    // if (parsed.length > 0) {
+    //   this.textValid = true;
+    //   let date = parsed[0].date().toISOString().slice(0,10);
+    //   this.date = date;
+    //   this.onChange(this.date);
+    // } else {
+    //   this.textValid = false;
+    //   this.date = '';
+    //   this.onChange(this.date);
+    // }
     let parsed = chrono.parse(this.text);
     if (parsed.length > 0) {
       this.textValid = true;
       let date = parsed[0].date().toISOString().slice(0,10);
       this.date = date;
+      this.text = this.date;
       this.onChange(this.date);
     } else {
       this.textValid = false;
@@ -54,8 +140,10 @@ export class ChronoDateComponent implements OnInit, ControlValueAccessor {
   };
 
   calendarUpdate($event) {
+    console.log("hello");
     this.textValid = true;
-    this.text = '';
+    // this.text = '';
+    this.text = this.date;
     this.onChange(this.date);
   }
 

--- a/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.html
+++ b/projects/angular2-query-builder/src/lib/query-builder/query-builder.component.html
@@ -130,8 +130,8 @@
                   [disabled]="disabled" *ngSwitchCase="'string'" type="text">
                 <input [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
                   [disabled]="disabled" *ngSwitchCase="'number'" type="number">
-                <input [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
-                  [disabled]="disabled" *ngSwitchCase="'date'" type="date">
+                <chrono-date [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
+                  [disabled]="disabled" *ngSwitchCase="'date'"></chrono-date>
                 <input [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"
                   [disabled]="disabled" *ngSwitchCase="'time'" type="time">
                 <select [ngClass]="getClassNames('inputControl')" [(ngModel)]="rule.value" (ngModelChange)="changeInput()"

--- a/projects/angular2-query-builder/tsconfig.lib.json
+++ b/projects/angular2-query-builder/tsconfig.lib.json
@@ -17,7 +17,8 @@
       "es5",
       "es6",
       "dom"
-    ]
+    ],
+    "allowSyntheticDefaultImports": true
   },
   "angularCompilerOptions": {
     "skipTemplateCodegen": true,


### PR DESCRIPTION
Created a custom chrono-date component to use for dates instead of the standard HTML input with type=date. This new component has a text box and a calendar input. Users can choose to input into either. The text box will parse the text on blur using the chrono library to get a date. Some examples of text to input are "march 1 2020", "yesterday", "last friday", etc.

You can see the new component in action by running the demo app. The input for the Birthday field in the query builder now uses the new component.